### PR TITLE
Updated for Bannerlord 1.7.0

### DIFF
--- a/PartyScreenEnhancements/ViewModel/SortAllTroopsVM.cs
+++ b/PartyScreenEnhancements/ViewModel/SortAllTroopsVM.cs
@@ -89,7 +89,7 @@ namespace PartyScreenEnhancements.ViewModel
         {
             if (rosterToSort == null || rosterToSort.Count == 0 || toSort == null || toSort.IsEmpty()) return;
 
-            var leaderOfParty = party?.Leader;
+            var leaderOfParty = party?.LeaderHero.CharacterObject;
             toSort.StableSort(sorter);
 
             if (leaderOfParty != null)


### PR DESCRIPTION
Seems like I had only to change `PartyBase.Leader` to `PartyBase.LeaderHero.CharacterObject` and recompile to fix the `MissingMethodException`. Weird.